### PR TITLE
Fix grammar in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bash Language Server
 
-Bash language server implementation based on [Tree Sitter][tree-sitter] and it's
+Bash language server implementation based on [Tree Sitter][tree-sitter] and its
 [grammar for Bash][tree-sitter-bash].
 
 ## Features


### PR DESCRIPTION
"it's" is a contraction of "it is". The following sentence doesn't make sense.

> Bash language server implementation based on Tree Sitter and it is grammar for Bash.

The possessive pronoun of "its" should be used instead in this context.