### PR TITLE
Fix typo in missing language server error

### DIFF
--- a/vscode-client/src/extension.ts
+++ b/vscode-client/src/extension.ts
@@ -55,7 +55,7 @@ function start(context: ExtensionContext, command: string) {
 }
 
 function handleMissingExecutable() {
-  const message = `Can't find bash-langauge-server on your PATH. Please install it using npm i -g bash-language-server.`
+  const message = `Can't find bash-language-server on your PATH. Please install it using npm i -g bash-language-server.`
   const options = {
     modal: false,
   }


### PR DESCRIPTION
Should be `language` instead of `langauge`.