### PR TITLE
Fix compilation

### DIFF
--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -63,9 +63,7 @@ whenever you've made a change, and then reload you vscode window to re-launch
 the server.
 
 ```
-cd server
-npm run compile
-npm i -g .
+npm run reinstall-server
 # Reload vscode window.
 ```
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test:coverage": "npm run test -- --coverage",
     "test:watch": "npm run test -- --watch",
     "check": "npm run lint && npm run test",
-    "check:bail": "npm run lint:bail && npm run test"
+    "check:bail": "npm run lint:bail && npm run test",
+    "reinstall-server": "npm run compile && npm i -g ./server"
   },
   "devDependencies": {
     "@types/jest": "^22.2.2",
@@ -63,5 +64,6 @@
       "text-summary",
       "html"
     ]
-  }
+  },
+  "dependencies": {}
 }

--- a/server/package.json
+++ b/server/package.json
@@ -23,7 +23,7 @@
     "vscode-languageserver": "^3.5.0"
   },
   "scripts": {
-    "compile": "tsc -p ./",
+    "compile": "rm -rf out && tsc -p ./",
     "compile:watch": "tsc -w -p ./"
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -14,6 +14,9 @@
     "sourceMap": true
   },
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "**/__tests__/*",
+    "server/setupJest.ts",
+    "testing"
   ]
 }

--- a/vscode-client/package.json
+++ b/vscode-client/package.json
@@ -28,8 +28,8 @@
   "main": "./out/src/extension",
   "contributes": {},
   "scripts": {
-    "vscode:prepublish": "tsc -p ./",
-    "compile": "tsc -p ./",
+    "vscode:prepublish": "npm run compile",
+    "compile": "rm -rf out && tsc -p ./",
     "compile:watch": "tsc -w -p ./",
     "update-vscode": "node ./node_modules/vscode/bin/install",
     "postinstall": "node ./node_modules/vscode/bin/install"


### PR DESCRIPTION
When introducing the integration tests (https://github.com/mads-hartmann/bash-language-server/pull/14) I broke the build. 

The TypeScript compilers output path depends magically on the files in the source directory. So when introducing new test setup files, the compilation path was suddenly `server/out/server/server.js` instead of `server/out/server.js`. 

The main problem here is that we don't clean the compilation directories... As I tested that it worked after introducing integration tests, but the old files were still in my local copy of `out`.

This PR:
- fixes the build
- introduces cleaning before building
- adds a convenience method for working on the server (compile and reinstall)