### PR TITLE
More reliable npm command execution on windows

### DIFF
--- a/vscode-client/src/util.ts
+++ b/vscode-client/src/util.ts
@@ -7,7 +7,7 @@ function isWindows() {
 
 function getBasePath(): Promise<string> {
   return new Promise((resolve, reject) => {
-    const npmBin = isWindows() ? 'npm.cmd' : 'npm';
+    const npmBin = isWindows() ? 'npm.cmd' : 'npm'
     execFile(npmBin, ['bin', '-g'], (err, stdout) => {
       if (err) {
         reject(err)

--- a/vscode-client/src/util.ts
+++ b/vscode-client/src/util.ts
@@ -7,7 +7,8 @@ function isWindows() {
 
 function getBasePath(): Promise<string> {
   return new Promise((resolve, reject) => {
-    execFile('npm', ['bin', '-g'], (err, stdout) => {
+    const npmBin = isWindows() ? 'npm.cmd' : 'npm';
+    execFile(npmBin, ['bin', '-g'], (err, stdout) => {
       if (err) {
         reject(err)
       }


### PR DESCRIPTION
Append '.cmd' extension when spawning child process for npm command on windows as '.cmd'/'.bat' files are not included when searching for executable by basename.