### PR TITLE
Fix build script and bump server to version 1.5.1

### DIFF
--- a/scripts/release-client.sh
+++ b/scripts/release-client.sh
@@ -4,4 +4,6 @@ set -euo pipefail
 
 version=$(cat server/package.json | jq -r .version)
 
+yarn && yarn run check:bail
+
 cd vscode-client && vsce publish ${version}

--- a/scripts/release-server.sh
+++ b/scripts/release-server.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 version=$(cat server/package.json | jq -r .version)
 tag="server-${version}"
 
+yarn && yarn run check:bail
+
 git tag -a "${tag}" -m "Release ${version} of the bash-language-server package"
 git push origin "${tag}"
 

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Bash Language Server
 
+## 1.5.1
+
+* Upgrade `tree-sitter` and `tree-sitter-bash`
+* Fixed build issue with 1.5.0
+
 ## 1.5.0
 
 * Upgrade `tree-sitter` and `tree-sitter-bash`

--- a/server/package.json
+++ b/server/package.json
@@ -27,7 +27,8 @@
     "vscode-languageserver": "^4.1.1"
   },
   "scripts": {
-    "compile": "rm -rf out && tsc -p ./",
-    "compile:watch": "tsc -w -p ./"
+    "compile": "rm -rf out && ../node_modules/.bin/tsc -p ./",
+    "compile:watch": "../node_modules/.bin/tsc -w -p ./",
+    "prepublishOnly": "yarn run compile"
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
   "description": "A language server for Bash",
   "author": "Mads Hartmann",
   "license": "MIT",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "publisher": "mads-hartmann",
   "main": "out/server.js",
   "bin": {


### PR DESCRIPTION
We made a mistake with 1.5.0 where we didn't compile the server before publishing...

This PR hopefully fixes this for the future. And prepares for publishing a new version.