### PR TITLE
Add missing nodes warning + grammar update

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Bash Language Server
 
+## 1.5.3
+
+* Support for showing warning for missing nodes
+
 ## 1.5.2
 
 * Upgrade `tree-sitter` to `0.13.5` and `tree-sitter-bash` to `0.13.2`

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.5.3
 
 * Support for showing warning for missing nodes
+* Upgrade `tree-sitter-bash` to `0.13.3`
 
 ## 1.5.2
 

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
   "description": "A language server for Bash",
   "author": "Mads Hartmann",
   "license": "MIT",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "publisher": "mads-hartmann",
   "main": "out/server.js",
   "bin": {

--- a/server/package.json
+++ b/server/package.json
@@ -21,7 +21,7 @@
     "request": "^2.83.0",
     "request-promise-native": "^1.0.5",
     "tree-sitter": "^0.13.5",
-    "tree-sitter-bash": "^0.13.2",
+    "tree-sitter-bash": "^0.13.3",
     "turndown": "^4.0.2",
     "urijs": "^1.19.1",
     "vscode-languageserver": "^4.1.1"

--- a/server/src/__tests__/__snapshots__/analyzer.test.ts.snap
+++ b/server/src/__tests__/__snapshots__/analyzer.test.ts.snap
@@ -1,6 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`analyze returns a list of errors for a file with errors 1`] = `
+exports[`analyze returns a list of errors for a file with a missing node 1`] = `
+Array [
+  Object {
+    "message": "Syntax error: expected \\"fi\\" somewhere in the file",
+    "range": Object {
+      "end": Object {
+        "character": 0,
+        "line": 12,
+      },
+      "start": Object {
+        "character": 0,
+        "line": 12,
+      },
+    },
+    "severity": 2,
+  },
+]
+`;
+
+exports[`analyze returns a list of errors for a file with parsing errors 1`] = `
 Array [
   Object {
     "message": "Failed to parse expression",

--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -9,12 +9,18 @@ beforeEach(() => {
 })
 
 describe('analyze', () => {
-  it('returns an empty list for a file with no errors', () => {
+  it('returns an empty list of errors for a file with no parsing errors', () => {
     const result = analyzer.analyze(CURRENT_URI, FIXTURES.INSTALL)
     expect(result).toEqual([])
   })
 
-  it('returns a list of errors for a file with errors', () => {
+  it('returns a list of errors for a file with a missing node', () => {
+    const result = analyzer.analyze(CURRENT_URI, FIXTURES.MISSING_NODE)
+    expect(result).not.toEqual([])
+    expect(result).toMatchSnapshot()
+  })
+
+  it('returns a list of errors for a file with parsing errors', () => {
     const result = analyzer.analyze(CURRENT_URI, FIXTURES.PARSE_PROBLEMS)
     expect(result).not.toEqual([])
     expect(result).toMatchSnapshot()

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -839,9 +839,9 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
-tree-sitter-bash@^0.13.2:
-  version "0.13.2"
-  resolved "https://registry.yarnpkg.com/tree-sitter-bash/-/tree-sitter-bash-0.13.2.tgz#e3a0b049df7edf0bea74b8bf58f29241e3c73463"
+tree-sitter-bash@^0.13.3:
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/tree-sitter-bash/-/tree-sitter-bash-0.13.3.tgz#b9d3bebb0ff9ddc3692b2a96a02872beef5af53f"
   dependencies:
     nan "^2.10.0"
     prebuild-install "^5.0.0"

--- a/testing/fixtures.ts
+++ b/testing/fixtures.ts
@@ -4,9 +4,14 @@ import * as LSP from 'vscode-languageserver'
 
 const base = path.join(__dirname, './fixtures/')
 
+function getFixture(filename: string) {
+  return LSP.TextDocument.create('foo', 'bar', 0, fs.readFileSync(path.join(base, filename), 'utf8'))
+}
+
 const FIXTURES = {
-  INSTALL: LSP.TextDocument.create('foo', 'bar', 0, fs.readFileSync(path.join(base, 'install.sh'), 'utf8')),
-  PARSE_PROBLEMS: LSP.TextDocument.create('foo', 'bar', 0, fs.readFileSync(path.join(base, 'parse-problems.sh'), 'utf8')),
+  MISSING_NODE: getFixture('missing-node.sh'),
+  INSTALL: getFixture('install.sh'),
+  PARSE_PROBLEMS: getFixture('parse-problems.sh'),
 }
 
 export default FIXTURES

--- a/testing/fixtures/missing-node.sh
+++ b/testing/fixtures/missing-node.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# set -x
+set -e
+
+PATH_INPUT=src/in.js
+PATH_OUTPUT=src/out.js
+
+if [[ $PATH_INPUT -nt $PATH_OUTPUT ]]; then
+  babel --compact false ${PATH_INPUT} > ${PATH_OUTPUT}
+f
+
+echo "test"

--- a/vscode-client/src/extension.ts
+++ b/vscode-client/src/extension.ts
@@ -10,7 +10,7 @@ import {
 
 import { getServerInfo } from './util'
 
-const MINIMUM_SERVER_VERSION = '1.3.0'
+const MINIMUM_SERVER_VERSION = '1.5.2'
 
 export async function activate(context: ExtensionContext) {
   try {


### PR DESCRIPTION
Closes https://github.com/mads-hartmann/bash-language-server/issues/74

Currently, the extension is just silent if a node is missing, but this PR adds an error to the bottom of a file if a node is missing.

<img width="463" alt="screenshot 2018-08-21 22 05 07" src="https://user-images.githubusercontent.com/1260305/44426208-51233100-a58e-11e8-8ee3-5f0233edf0b6.png">


Unfortunately, we cannot show the missing node where it occurs... So we should evaluate if this PR gives any additional value. See https://github.com/tree-sitter/tree-sitter-bash/issues/30

Besides, I'm bumping the version number and increase the required server version to the current release (a lot are probably using an old version).