### PR TITLE
Assign symbol kind for local variables

### DIFF
--- a/server/src/__tests__/__snapshots__/analyzer.test.ts.snap
+++ b/server/src/__tests__/__snapshots__/analyzer.test.ts.snap
@@ -133,7 +133,7 @@ Array [
       "name": "ret",
       "type": "function",
     },
-    "kind": 1,
+    "kind": 6,
     "label": "ret",
   },
   Object {
@@ -141,7 +141,7 @@ Array [
       "name": "configures",
       "type": "function",
     },
-    "kind": 1,
+    "kind": 6,
     "label": "configures",
   },
   Object {
@@ -149,7 +149,7 @@ Array [
       "name": "npm_config_loglevel",
       "type": "function",
     },
-    "kind": 1,
+    "kind": 6,
     "label": "npm_config_loglevel",
   },
   Object {
@@ -157,7 +157,7 @@ Array [
       "name": "node",
       "type": "function",
     },
-    "kind": 1,
+    "kind": 6,
     "label": "node",
   },
   Object {
@@ -165,7 +165,7 @@ Array [
       "name": "TMP",
       "type": "function",
     },
-    "kind": 1,
+    "kind": 6,
     "label": "TMP",
   },
   Object {
@@ -173,7 +173,7 @@ Array [
       "name": "BACK",
       "type": "function",
     },
-    "kind": 1,
+    "kind": 6,
     "label": "BACK",
   },
   Object {
@@ -181,7 +181,7 @@ Array [
       "name": "tar",
       "type": "function",
     },
-    "kind": 1,
+    "kind": 6,
     "label": "tar",
   },
   Object {
@@ -189,7 +189,7 @@ Array [
       "name": "MAKE",
       "type": "function",
     },
-    "kind": 1,
+    "kind": 6,
     "label": "MAKE",
   },
   Object {
@@ -197,7 +197,7 @@ Array [
       "name": "make",
       "type": "function",
     },
-    "kind": 1,
+    "kind": 6,
     "label": "make",
   },
   Object {
@@ -205,7 +205,7 @@ Array [
       "name": "clean",
       "type": "function",
     },
-    "kind": 1,
+    "kind": 6,
     "label": "clean",
   },
   Object {
@@ -213,7 +213,7 @@ Array [
       "name": "node_version",
       "type": "function",
     },
-    "kind": 1,
+    "kind": 6,
     "label": "node_version",
   },
   Object {
@@ -221,7 +221,7 @@ Array [
       "name": "t",
       "type": "function",
     },
-    "kind": 1,
+    "kind": 6,
     "label": "t",
   },
   Object {
@@ -229,7 +229,7 @@ Array [
       "name": "url",
       "type": "function",
     },
-    "kind": 1,
+    "kind": 6,
     "label": "url",
   },
   Object {
@@ -237,7 +237,7 @@ Array [
       "name": "ver",
       "type": "function",
     },
-    "kind": 1,
+    "kind": 6,
     "label": "ver",
   },
   Object {
@@ -245,7 +245,7 @@ Array [
       "name": "isnpm10",
       "type": "function",
     },
-    "kind": 1,
+    "kind": 6,
     "label": "isnpm10",
   },
   Object {
@@ -253,8 +253,84 @@ Array [
       "name": "NODE",
       "type": "function",
     },
-    "kind": 1,
+    "kind": 6,
     "label": "NODE",
+  },
+]
+`;
+
+exports[`findSymbols issue 101 1`] = `
+Array [
+  Object {
+    "kind": 12,
+    "location": Object {
+      "range": Object {
+        "end": Object {
+          "character": 1,
+          "line": 14,
+        },
+        "start": Object {
+          "character": 0,
+          "line": 3,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "add_a_user",
+  },
+  Object {
+    "containerName": "add_a_user",
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
+          "character": 9,
+          "line": 5,
+        },
+        "start": Object {
+          "character": 2,
+          "line": 5,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "USER",
+  },
+  Object {
+    "containerName": "add_a_user",
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
+          "character": 13,
+          "line": 6,
+        },
+        "start": Object {
+          "character": 2,
+          "line": 6,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "PASSWORD",
+  },
+  Object {
+    "containerName": "add_a_user",
+    "kind": 13,
+    "location": Object {
+      "range": Object {
+        "end": Object {
+          "character": 13,
+          "line": 9,
+        },
+        "start": Object {
+          "character": 2,
+          "line": 9,
+        },
+      },
+      "uri": "dummy-uri.sh",
+    },
+    "name": "COMMENTS",
   },
 ]
 `;
@@ -262,7 +338,7 @@ Array [
 exports[`findSymbols returns a list of SymbolInformation if uri is found 1`] = `
 Array [
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -279,7 +355,7 @@ Array [
     "name": "ret",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -296,7 +372,7 @@ Array [
     "name": "ret",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -313,7 +389,7 @@ Array [
     "name": "ret",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -330,7 +406,7 @@ Array [
     "name": "ret",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -347,7 +423,7 @@ Array [
     "name": "ret",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -364,7 +440,7 @@ Array [
     "name": "ret",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -381,7 +457,7 @@ Array [
     "name": "ret",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -398,7 +474,7 @@ Array [
     "name": "ret",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -415,7 +491,7 @@ Array [
     "name": "ret",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -432,7 +508,7 @@ Array [
     "name": "ret",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -449,7 +525,7 @@ Array [
     "name": "ret",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -466,7 +542,7 @@ Array [
     "name": "ret",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -483,7 +559,7 @@ Array [
     "name": "ret",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -500,7 +576,7 @@ Array [
     "name": "ret",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -517,7 +593,7 @@ Array [
     "name": "ret",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -534,7 +610,7 @@ Array [
     "name": "ret",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -551,7 +627,7 @@ Array [
     "name": "configures",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -568,7 +644,7 @@ Array [
     "name": "npm_config_loglevel",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -585,7 +661,7 @@ Array [
     "name": "npm_config_loglevel",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -602,7 +678,7 @@ Array [
     "name": "node",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -619,7 +695,7 @@ Array [
     "name": "TMP",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -636,7 +712,7 @@ Array [
     "name": "TMP",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -653,7 +729,7 @@ Array [
     "name": "TMP",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -670,7 +746,7 @@ Array [
     "name": "BACK",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -687,7 +763,7 @@ Array [
     "name": "tar",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -704,7 +780,7 @@ Array [
     "name": "tar",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -721,7 +797,7 @@ Array [
     "name": "tar",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -738,7 +814,7 @@ Array [
     "name": "MAKE",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -755,7 +831,7 @@ Array [
     "name": "make",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -772,7 +848,7 @@ Array [
     "name": "make",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -789,7 +865,7 @@ Array [
     "name": "make",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -806,7 +882,7 @@ Array [
     "name": "make",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -823,7 +899,7 @@ Array [
     "name": "make",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -840,7 +916,7 @@ Array [
     "name": "make",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -857,7 +933,7 @@ Array [
     "name": "clean",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -874,7 +950,7 @@ Array [
     "name": "clean",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -891,7 +967,7 @@ Array [
     "name": "node_version",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -908,7 +984,7 @@ Array [
     "name": "t",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -925,7 +1001,7 @@ Array [
     "name": "t",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -942,7 +1018,7 @@ Array [
     "name": "url",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -959,7 +1035,7 @@ Array [
     "name": "url",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -976,7 +1052,7 @@ Array [
     "name": "ver",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -993,7 +1069,7 @@ Array [
     "name": "isnpm10",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -1010,7 +1086,7 @@ Array [
     "name": "isnpm10",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -1027,7 +1103,7 @@ Array [
     "name": "isnpm10",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {
@@ -1044,7 +1120,7 @@ Array [
     "name": "NODE",
   },
   Object {
-    "kind": undefined,
+    "kind": 13,
     "location": Object {
       "range": Object {
         "end": Object {

--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -64,6 +64,13 @@ describe('findSymbols', () => {
     expect(result).not.toEqual([])
     expect(result).toMatchSnapshot()
   })
+
+  it('issue 101', () => {
+    analyzer.analyze(CURRENT_URI, FIXTURES.ISSUE101)
+    const result = analyzer.findSymbols(CURRENT_URI)
+    expect(result).not.toEqual([])
+    expect(result).toMatchSnapshot()
+  })
 })
 
 describe('wordAtPoint', () => {

--- a/server/src/analyser.ts
+++ b/server/src/analyser.ts
@@ -77,6 +77,7 @@ export default class Analyzer {
     // These keys are using underscores as that's the naming convention in tree-sitter.
     environment_variable_assignment: LSP.SymbolKind.Variable,
     function_definition: LSP.SymbolKind.Function,
+    variable_assignment: LSP.SymbolKind.Variable,
   }
 
   /**

--- a/testing/fixtures.ts
+++ b/testing/fixtures.ts
@@ -10,6 +10,7 @@ function getFixture(filename: string) {
 
 const FIXTURES = {
   MISSING_NODE: getFixture('missing-node.sh'),
+  ISSUE101: getFixture('issue101.sh'),
   INSTALL: getFixture('install.sh'),
   PARSE_PROBLEMS: getFixture('parse-problems.sh'),
 }

--- a/testing/fixtures/issue101.sh
+++ b/testing/fixtures/issue101.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# A simple script with a function...
+
+add_a_user()
+{
+  USER=$1
+  PASSWORD=$2
+  shift; shift;
+  # Having shifted twice, the rest is now comments ...
+  COMMENTS=$@
+  echo "Adding user $USER ..."
+  echo useradd -c "$COMMENTS" $USER
+  echo passwd $USER $PASSWORD
+  echo "Added user $USER ($COMMENTS) with pass $PASSWORD"
+}
+
+###
+# Main body of script starts here
+###
+echo "Start of script..."
+add_a_user bob letmein Bob Holness the presenter
+add_a_user fred badpassword Fred Durst the singer
+add_a_user bilko worsepassword Sgt. Bilko the role model
+echo "End of script..."


### PR DESCRIPTION
Closes #101.

Variables inside a function were not getting assigned a `kind` when it was being turned into a `SymbolInformation` type. The absence of this required field was causing errors in strict LSP client implementations such as LSP4E.