### PR TITLE
Only analyze files that end with .sh in their names

### DIFF
--- a/server/src/analyser.ts
+++ b/server/src/analyser.ts
@@ -51,12 +51,15 @@ export default class Analyzer {
           const analyzer = new Analyzer()
           paths.forEach(p => {
             const absolute = Path.join(rootPath, p)
-            const uri = 'file://' + absolute
-            connection.console.log('Analyzing ' + uri)
-            analyzer.analyze(
-              uri,
-              LSP.TextDocument.create(uri, 'shell', 1, fs.readFileSync(absolute, 'utf8')),
-            )
+            // only analyze files, glob pattern may match directories
+            if (fs.existsSync(absolute) && fs.lstatSync(absolute).isFile()) {
+              const uri = 'file://' + absolute
+              connection.console.log('Analyzing ' + uri)
+              analyzer.analyze(
+                uri,
+                LSP.TextDocument.create(uri, 'shell', 1, fs.readFileSync(absolute, 'utf8')),
+              )
+            }
           })
           resolve(analyzer)
         }

--- a/server/src/analyser.ts
+++ b/server/src/analyser.ts
@@ -57,7 +57,12 @@ export default class Analyzer {
               connection.console.log('Analyzing ' + uri)
               analyzer.analyze(
                 uri,
-                LSP.TextDocument.create(uri, 'shell', 1, fs.readFileSync(absolute, 'utf8')),
+                LSP.TextDocument.create(
+                  uri,
+                  'shell',
+                  1,
+                  fs.readFileSync(absolute, 'utf8'),
+                ),
               )
             }
           })


### PR DESCRIPTION
Closes #102.

Skip out on trying to parse directories that have a `.sh` suffix in their names. Otherwise, the language server will crash when trying to read a directory as a file.