### PR TITLE
Fix issue #83

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -204,7 +204,17 @@ export default class BashServer {
       },
     }))
 
-    return [...symbolCompletions, ...programCompletions, ...builtinsCompletions]
+    const allCompletions = [
+      ...symbolCompletions,
+      ...programCompletions,
+      ...builtinsCompletions,
+    ]
+
+    // Filter to only return suffixes of the current word
+    const currentWord = this.getWordAtPoint(pos)
+    return allCompletions.filter(
+      (x: LSP.CompletionItem) => x.label && x.label.startsWith(currentWord),
+    )
   }
 
   private async onCompletionResolve(

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -212,9 +212,15 @@ export default class BashServer {
 
     // Filter to only return suffixes of the current word
     const currentWord = this.getWordAtPoint(pos)
-    return allCompletions.filter(
-      (x: LSP.CompletionItem) => x.label && x.label.startsWith(currentWord),
-    )
+    if (currentWord) {
+      return allCompletions.filter(
+        (x: LSP.CompletionItem) => x.label && x.label.startsWith(currentWord),
+      )
+    } else {
+      // If we couldn't determine the word for some reason (like being at the beginning of a line)
+      // then return all completions
+      return allCompletions
+    }
   }
 
   private async onCompletionResolve(


### PR DESCRIPTION
This is an attempt to fix #83. See my comments there for more context on the problem.

This PR adds filtering to the completion results, so you only get complete results for which the current word you're typing is a prefix.

The main challenge here was to improve the `analyser.wordAtPoint` function so that it retrieves the correct word when you're at the edge of a word (as is usually the case when using completion).

Note: I suspect that similar boundary issues are the reason for the "Hack" code on line 321 of the original code, so maybe that can be removed now but I'm not sure how to test.

@skovhus 