### PR TITLE
Improve error discovery when the LSP process cannot be started

### DIFF
--- a/vscode-client/src/extension.ts
+++ b/vscode-client/src/extension.ts
@@ -29,7 +29,7 @@ export async function activate(context: ExtensionContext) {
 
     start(context, command, explainshellEndpoint, highlightParsingErrors)
   } catch (error) {
-    handleMissingExecutable()
+    handleStartError(error)
   }
 }
 
@@ -93,7 +93,9 @@ function handleOutdatedExecutable() {
   window.showErrorMessage(message, { modal: false })
 }
 
-function handleMissingExecutable() {
-  const message = `Can't find bash-language-server on your PATH. Please install it using "npm i -g bash-language-server".`
+function handleStartError(error: Error) {
+  const message =
+    'Unable to start bash-language-server, did you install it? Open DevTools for additional details.'
+  console.error(error)
   window.showErrorMessage(message, { modal: false })
 }


### PR DESCRIPTION
When the `bash-language-server` cannot be started or found the user only sees a message that the process could not be found instead of seeing the actual reason for the failure.

This message got me very confused when I installed the extension because I made sure I had the `bash-language-server` installed and could find it in my `PATH` but I thought VS Code somehow fails to find it. The actual problem was that I upgraded to Node.js 12 and the process failed to start as it was not compiled against the correct Node.js version. I only discovered that when I actually tried to start the server.

This PR improves the discovery of the failure by showing a more generic error message and guiding users to the DevTools console where the actual error is logged.