### PR TITLE
 see More error info in vscode `extension.js`

### DIFF
--- a/vscode-client/src/extension.ts
+++ b/vscode-client/src/extension.ts
@@ -29,7 +29,7 @@ export async function activate(context: ExtensionContext) {
 
     start(context, command, explainshellEndpoint, highlightParsingErrors)
   } catch (error) {
-    handleMissingExecutable()
+    handleMissingExecutable(error.toString())
   }
 }
 
@@ -93,7 +93,7 @@ function handleOutdatedExecutable() {
   window.showErrorMessage(message, { modal: false })
 }
 
-function handleMissingExecutable() {
-  const message = `Can't find bash-language-server on your PATH. Please install it using "npm i -g bash-language-server".`
+function handleMissingExecutable(error) {
+  const message = `Can't find bash-language-server on your PATH. Please install it using "npm i -g bash-language-server".\n` + error
   window.showErrorMessage(message, { modal: false })
 }


### PR DESCRIPTION
To see More error info in vscode.
Why the server is not running which may help solve issues like
https://github.com/mads-hartmann/bash-language-server/issues/41
https://github.com/mads-hartmann/bash-language-server/issues/96

Please Output More info if needed.

By the way, may and how can i use `base-language-server` in shells or web?