### PR TITLE
Man pages formatting fixed

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -221,13 +221,22 @@ export default class BashServer {
         const doc = await this.executables.documentation(name)
         return {
           ...item,
-          detail: doc,
+          documentation: {
+            // LSP.MarkupContent
+            value: doc,
+            // Passed as plaintext to not break man pages formatting
+            kind: 'plaintext',
+          },
         }
       } else if (type === 'builtin') {
         const doc = await Builtins.documentation(name)
         return {
           ...item,
-          detail: doc,
+          documentation: {
+            // LSP.MarkupContent
+            value: doc,
+            kind: 'plaintext',
+          },
         }
       } else {
         return item


### PR DESCRIPTION
This fixes neoclide/coc.nvim#911

Now man pages are correctly formatted on `completionItem/resolve`

![Screenshot_20191210_210452](https://user-images.githubusercontent.com/39320840/70585183-67913980-1b91-11ea-8532-79cb7a510bf9.png)