### PR TITLE
Extend and make glob pattern configurable

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Bash Language Server
 
+## 1.8.0
+
+* Extend file glob used for pre-analyzing files from `**/*.sh` to `**/*@(.sh|.inc|.bash|.command)`
+* Make file glob configurable with `GLOB_PATTERN` environment variable
+
 ## 1.7.0
 
 * Add PATH tilde expansion

--- a/server/package.json
+++ b/server/package.json
@@ -18,7 +18,7 @@
     "node": "*"
   },
   "dependencies": {
-    "glob": "^7.1.2",
+    "glob": "^7.1.6",
     "request": "^2.83.0",
     "request-promise-native": "^1.0.5",
     "turndown": "^4.0.2",

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
   "description": "A language server for Bash",
   "author": "Mads Hartmann",
   "license": "MIT",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "publisher": "mads-hartmann",
   "main": "./out/server.js",
   "typings": "./out/server.d.ts",

--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -1,4 +1,4 @@
-import FIXTURES from '../../../testing/fixtures'
+import FIXTURES, { FIXTURE_FOLDER } from '../../../testing/fixtures'
 import Analyzer from '../analyser'
 import { initializeParser } from '../parser'
 
@@ -95,5 +95,53 @@ describe('findSymbolCompletions', () => {
   it('return a list of symbols', () => {
     analyzer.analyze(CURRENT_URI, FIXTURES.INSTALL)
     expect(analyzer.findSymbolCompletions(CURRENT_URI)).toMatchSnapshot()
+  })
+})
+
+describe('fromRoot', () => {
+  it('initializes an analyzer from a root', async () => {
+    const parser = await initializeParser()
+
+    jest.spyOn(Date, 'now').mockImplementation(() => 0)
+
+    const connection: any = {
+      console: {
+        log: jest.fn(),
+      },
+    }
+
+    const newAnalyzer = await Analyzer.fromRoot({
+      connection,
+      rootPath: FIXTURE_FOLDER,
+      parser,
+    })
+
+    expect(newAnalyzer).toBeDefined()
+
+    expect(connection.console.log).toHaveBeenCalledTimes(5)
+    expect(connection.console.log).toHaveBeenNthCalledWith(
+      1,
+      'Analyzing file:///Users/kenneth/git/bash-language-server/testing/fixtures/install.sh',
+    )
+
+    expect(connection.console.log).toHaveBeenNthCalledWith(
+      2,
+      'Analyzing file:///Users/kenneth/git/bash-language-server/testing/fixtures/issue101.sh',
+    )
+
+    expect(connection.console.log).toHaveBeenNthCalledWith(
+      3,
+      'Analyzing file:///Users/kenneth/git/bash-language-server/testing/fixtures/missing-node.sh',
+    )
+
+    expect(connection.console.log).toHaveBeenNthCalledWith(
+      4,
+      'Analyzing file:///Users/kenneth/git/bash-language-server/testing/fixtures/parse-problems.sh',
+    )
+
+    expect(connection.console.log).toHaveBeenNthCalledWith(
+      5,
+      'Analyzer finished after 0 seconds',
+    )
   })
 })

--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -119,7 +119,7 @@ describe('fromRoot', () => {
     expect(newAnalyzer).toBeDefined()
 
     const FIXTURE_FILES_MATCHING_GLOB = 8
-    const LOG_LINES = FIXTURE_FILES_MATCHING_GLOB + 2
+    const LOG_LINES = FIXTURE_FILES_MATCHING_GLOB + 3
 
     expect(connection.console.log).toHaveBeenCalledTimes(LOG_LINES)
     expect(connection.console.log).toHaveBeenNthCalledWith(

--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -118,29 +118,27 @@ describe('fromRoot', () => {
 
     expect(newAnalyzer).toBeDefined()
 
-    expect(connection.console.log).toHaveBeenCalledTimes(5)
+    const FIXTURE_FILES_MATCHING_GLOB = 8
+    const LOG_LINES = FIXTURE_FILES_MATCHING_GLOB + 2
+
+    expect(connection.console.log).toHaveBeenCalledTimes(LOG_LINES)
     expect(connection.console.log).toHaveBeenNthCalledWith(
       1,
-      'Analyzing file:///Users/kenneth/git/bash-language-server/testing/fixtures/install.sh',
+      expect.stringContaining('Analyzing files matching'),
     )
 
     expect(connection.console.log).toHaveBeenNthCalledWith(
       2,
-      'Analyzing file:///Users/kenneth/git/bash-language-server/testing/fixtures/issue101.sh',
+      'Analyzing file:///Users/kenneth/git/bash-language-server/testing/fixtures/extension.inc',
     )
 
     expect(connection.console.log).toHaveBeenNthCalledWith(
       3,
-      'Analyzing file:///Users/kenneth/git/bash-language-server/testing/fixtures/missing-node.sh',
+      'Analyzing file:///Users/kenneth/git/bash-language-server/testing/fixtures/install.sh',
     )
 
     expect(connection.console.log).toHaveBeenNthCalledWith(
-      4,
-      'Analyzing file:///Users/kenneth/git/bash-language-server/testing/fixtures/parse-problems.sh',
-    )
-
-    expect(connection.console.log).toHaveBeenNthCalledWith(
-      5,
+      LOG_LINES,
       'Analyzer finished after 0 seconds',
     )
   })

--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -128,16 +128,6 @@ describe('fromRoot', () => {
     )
 
     expect(connection.console.log).toHaveBeenNthCalledWith(
-      2,
-      'Analyzing file:///Users/kenneth/git/bash-language-server/testing/fixtures/extension.inc',
-    )
-
-    expect(connection.console.log).toHaveBeenNthCalledWith(
-      3,
-      'Analyzing file:///Users/kenneth/git/bash-language-server/testing/fixtures/install.sh',
-    )
-
-    expect(connection.console.log).toHaveBeenNthCalledWith(
       LOG_LINES,
       'Analyzer finished after 0 seconds',
     )

--- a/server/src/__tests__/config.test.ts
+++ b/server/src/__tests__/config.test.ts
@@ -7,6 +7,14 @@ describe('getExplainshellEndpoint', () => {
     expect(result).toBeNull()
   })
 
+  it('default to null in case of an empty string', () => {
+    process.env = {
+      EXPLAINSHELL_ENDPOINT: '',
+    }
+    const result = config.getExplainshellEndpoint()
+    expect(result).toBeNull()
+  })
+
   it('parses environment variable', () => {
     process.env = {
       EXPLAINSHELL_ENDPOINT: 'localhost:8080',
@@ -20,7 +28,15 @@ describe('getGlobPattern', () => {
   it('default to a basic glob', () => {
     process.env = {}
     const result = config.getGlobPattern()
-    expect(result).toEqual('**/*@(.sh|.inc|.bash|.command)')
+    expect(result).toEqual(config.DEFAULT_GLOB_PATTERN)
+  })
+
+  it('default to a basic glob in case of an empty string', () => {
+    process.env = {
+      GLOB_PATTERN: '',
+    }
+    const result = config.getGlobPattern()
+    expect(result).toEqual(config.DEFAULT_GLOB_PATTERN)
   })
 
   it('parses environment variable', () => {

--- a/server/src/__tests__/config.test.ts
+++ b/server/src/__tests__/config.test.ts
@@ -16,6 +16,22 @@ describe('getExplainshellEndpoint', () => {
   })
 })
 
+describe('getGlobPattern', () => {
+  it('default to a basic glob', () => {
+    process.env = {}
+    const result = config.getGlobPattern()
+    expect(result).toEqual('**/*@(.sh|.inc|.bash|.command)')
+  })
+
+  it('parses environment variable', () => {
+    process.env = {
+      GLOB_PATTERN: '*.*',
+    }
+    const result = config.getGlobPattern()
+    expect(result).toEqual('*.*')
+  })
+})
+
 describe('highlightParsingError', () => {
   it('default to true', () => {
     process.env = {}

--- a/server/src/analyser.ts
+++ b/server/src/analyser.ts
@@ -4,6 +4,7 @@ import * as URI from 'urijs'
 import * as LSP from 'vscode-languageserver'
 import * as Parser from 'web-tree-sitter'
 
+import { getGlobPattern } from './config'
 import { uniqueBasedOnHash } from './util/array'
 import { flattenArray, flattenObjectValues } from './util/flatten'
 import { getFilePaths } from './util/fs'
@@ -43,9 +44,14 @@ export default class Analyzer {
     const lookupStartTime = Date.now()
 
     if (rootPath) {
+      const globPattern = getGlobPattern()
+      connection.console.log(
+        `Analyzing files matching glob "${globPattern}" inside ${rootPath}`,
+      )
+
       // NOTE: An alternative would be to preload all files and analyze their
       // shebang (this would only be needed if we supported cross file referencing).
-      const filePaths = await getFilePaths({ globPattern: '**/*.sh', rootPath })
+      const filePaths = await getFilePaths({ globPattern, rootPath })
 
       filePaths.forEach(filePath => {
         const uri = `file://${filePath}`

--- a/server/src/analyser.ts
+++ b/server/src/analyser.ts
@@ -27,7 +27,7 @@ export default class Analyzer {
    * Initialize the Analyzer based on a connection to the client and an optional
    * root path.
    *
-   * If the rootPath is provided it will initialize all *.sh files it can find
+   * If the rootPath is provided it will initialize all shell files it can find
    * anywhere on that path. This non-exhaustive glob is used to preload the parser.
    */
   public static async fromRoot({

--- a/server/src/analyser.ts
+++ b/server/src/analyser.ts
@@ -41,31 +41,33 @@ export default class Analyzer {
   }): Promise<Analyzer> {
     const analyzer = new Analyzer(parser)
 
-    const lookupStartTime = Date.now()
-
     if (rootPath) {
       const globPattern = getGlobPattern()
       connection.console.log(
         `Analyzing files matching glob "${globPattern}" inside ${rootPath}`,
       )
 
+      const lookupStartTime = Date.now()
+      const getTimePassed = (): string =>
+        `${(Date.now() - lookupStartTime) / 1000} seconds`
+
       // NOTE: An alternative would be to preload all files and analyze their
-      // shebang (this would only be needed if we supported cross file referencing).
+      // shebang or mimetype, but it would be fairly expensive.
       const filePaths = await getFilePaths({ globPattern, rootPath })
+
+      connection.console.log(
+        `Glob resolved with ${filePaths.length} files after ${getTimePassed()}`,
+      )
 
       filePaths.forEach(filePath => {
         const uri = `file://${filePath}`
         connection.console.log(`Analyzing ${uri}`)
-
         const fileContent = fs.readFileSync(filePath, 'utf8')
-
         analyzer.analyze(uri, LSP.TextDocument.create(uri, 'shell', 1, fileContent))
       })
-    }
 
-    connection.console.log(
-      `Analyzer finished after ${(Date.now() - lookupStartTime) / 1000} seconds`,
-    )
+      connection.console.log(`Analyzer finished after ${getTimePassed()}`)
+    }
 
     return analyzer
   }

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -3,6 +3,13 @@ export function getExplainshellEndpoint(): string | null {
   return typeof EXPLAINSHELL_ENDPOINT !== 'undefined' ? EXPLAINSHELL_ENDPOINT : null
 }
 
+export function getGlobPattern(): string {
+  const { GLOB_PATTERN } = process.env
+  return typeof GLOB_PATTERN === 'string'
+    ? GLOB_PATTERN
+    : '**/*@(.sh|.inc|.bash|.command)'
+}
+
 export function getHighlightParsingError(): boolean {
   const { HIGHLIGHT_PARSING_ERRORS } = process.env
   return typeof HIGHLIGHT_PARSING_ERRORS !== 'undefined'

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -1,13 +1,17 @@
+export const DEFAULT_GLOB_PATTERN = '**/*@(.sh|.inc|.bash|.command)'
+
 export function getExplainshellEndpoint(): string | null {
   const { EXPLAINSHELL_ENDPOINT } = process.env
-  return typeof EXPLAINSHELL_ENDPOINT !== 'undefined' ? EXPLAINSHELL_ENDPOINT : null
+  return typeof EXPLAINSHELL_ENDPOINT === 'string' && EXPLAINSHELL_ENDPOINT.trim() !== ''
+    ? EXPLAINSHELL_ENDPOINT
+    : null
 }
 
 export function getGlobPattern(): string {
   const { GLOB_PATTERN } = process.env
-  return typeof GLOB_PATTERN === 'string'
+  return typeof GLOB_PATTERN === 'string' && GLOB_PATTERN.trim() !== ''
     ? GLOB_PATTERN
-    : '**/*@(.sh|.inc|.bash|.command)'
+    : DEFAULT_GLOB_PATTERN
 }
 
 export function getHighlightParsingError(): boolean {

--- a/server/src/util/fs.ts
+++ b/server/src/util/fs.ts
@@ -1,4 +1,5 @@
 import * as Fs from 'fs'
+import * as glob from 'glob'
 import * as Os from 'os'
 
 export function getStats(path: string): Promise<Fs.Stats> {
@@ -19,4 +20,25 @@ export function untildify(pathWithTilde: string): string {
   return homeDirectory
     ? pathWithTilde.replace(/^~(?=$|\/|\\)/, homeDirectory)
     : pathWithTilde
+}
+
+export async function getFilePaths({
+  globPattern,
+  rootPath,
+}: {
+  globPattern: string
+  rootPath: string
+}): Promise<string[]> {
+  return new Promise((resolve, reject) => {
+    glob(globPattern, { cwd: rootPath, nodir: true, absolute: true }, function(
+      err,
+      files,
+    ) {
+      if (err) {
+        return reject(err)
+      }
+
+      resolve(files)
+    })
+  })
 }

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -328,10 +328,10 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-glob@^7.1.2:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
-  integrity sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==
+glob@^7.1.6:
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
+  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"

--- a/testing/fixtures.ts
+++ b/testing/fixtures.ts
@@ -2,14 +2,14 @@ import * as fs from 'fs'
 import * as path from 'path'
 import * as LSP from 'vscode-languageserver'
 
-const base = path.join(__dirname, './fixtures/')
+export const FIXTURE_FOLDER = path.join(__dirname, './fixtures/')
 
 function getFixture(filename: string) {
   return LSP.TextDocument.create(
     'foo',
     'bar',
     0,
-    fs.readFileSync(path.join(base, filename), 'utf8'),
+    fs.readFileSync(path.join(FIXTURE_FOLDER, filename), 'utf8'),
   )
 }
 

--- a/testing/fixtures/extension
+++ b/testing/fixtures/extension
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "It works, but is not parsed initially"

--- a/testing/fixtures/extension.inc
+++ b/testing/fixtures/extension.inc
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "It works, but is not parsed initially"

--- a/testing/fixtures/extension.inc
+++ b/testing/fixtures/extension.inc
@@ -1,3 +1,9 @@
 #!/bin/sh
 
 echo "It works, but is not parsed initially"
+
+RED=`tput setaf 1`
+GREEN=`tput setaf 2`
+BLUE=`tput setaf 4`
+BOLD=`tput bold`
+RESET=`tput sgr0`

--- a/testing/fixtures/extension.inc
+++ b/testing/fixtures/extension.inc
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-echo "It works, but is not parsed initially"
-
 RED=`tput setaf 1`
 GREEN=`tput setaf 2`
 BLUE=`tput setaf 4`

--- a/testing/fixtures/not-a-shell-script.sh
+++ b/testing/fixtures/not-a-shell-script.sh
@@ -1,0 +1,4 @@
+if this is not a shell script, then it should not be parsed
+
+echo "Or is it?"
+

--- a/testing/fixtures/not-a-shell-script2.sh
+++ b/testing/fixtures/not-a-shell-script2.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env python2.7
+# set -x
+
+def func():
+  print 'hello world'

--- a/testing/fixtures/sourcing.sh
+++ b/testing/fixtures/sourcing.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+source ./extension.inc
+
+echo $RED 'Hello in red!'

--- a/vscode-client/package.json
+++ b/vscode-client/package.json
@@ -31,10 +31,15 @@
       "type": "object",
       "title": "Bash IDE configuration",
       "properties": {
+        "bashIde.globPattern": {
+          "type": "string",
+          "default": "**/*@(.sh|.inc|.bash|.command)",
+          "description": "Glob pattern for finding and parsing shell script files."
+        },
         "bashIde.highlightParsingErrors": {
           "type": "boolean",
           "default": true,
-          "description": "If enabled parsing errors will be highlighted as 'problems' "
+          "description": "If enabled parsing errors will be highlighted as problems."
         },
         "bashIde.explainshellEndpoint": {
           "type": "string",

--- a/vscode-client/src/extension.ts
+++ b/vscode-client/src/extension.ts
@@ -13,6 +13,8 @@ export async function activate(context: ExtensionContext) {
     .getConfiguration('bashIde')
     .get('explainshellEndpoint', '')
 
+  const globPattern = workspace.getConfiguration('bashIde').get('globPattern', false)
+
   const highlightParsingErrors = workspace
     .getConfiguration('bashIde')
     .get('highlightParsingErrors', false)
@@ -20,6 +22,7 @@ export async function activate(context: ExtensionContext) {
   const env: any = {
     ...process.env,
     EXPLAINSHELL_ENDPOINT: explainshellEndpoint,
+    GLOB_PATTERN: globPattern,
     HIGHLIGHT_PARSING_ERRORS: highlightParsingErrors,
   }
 

--- a/vscode-client/src/extension.ts
+++ b/vscode-client/src/extension.ts
@@ -13,7 +13,7 @@ export async function activate(context: ExtensionContext) {
     .getConfiguration('bashIde')
     .get('explainshellEndpoint', '')
 
-  const globPattern = workspace.getConfiguration('bashIde').get('globPattern', false)
+  const globPattern = workspace.getConfiguration('bashIde').get('globPattern', '')
 
   const highlightParsingErrors = workspace
     .getConfiguration('bashIde')


### PR DESCRIPTION
### Context

Issue: https://github.com/mads-hartmann/bash-language-server/issues/47

This builds on the work done a year ago (https://github.com/mads-hartmann/bash-language-server/pull/113). I ended up re-implementing it to get back into the problem space. Thanks to @przepompownia for re-booting this (https://github.com/mads-hartmann/bash-language-server/pull/156).

### This PR

Here we add support for configuring the glob pattern used when pre-analyzing all bash files (this is done to support jump to definition). Besides making it configurable we extend it from `**/*.sh` to `**/*@(.sh|.inc|.bash|.command)`.

I recommend reviewing commit by commit. 

### Next steps

This will introduce a few false positives as we do not parse the shebang or mime types  (yet), as I tried to document in the fixture folder.

Next step might be to implement the shebang part of https://github.com/mads-hartmann/bash-language-server/pull/113 or mime types (https://github.com/mads-hartmann/bash-language-server/issues/47#issuecomment-409279032) and consider the ideas introduced in https://github.com/mads-hartmann/bash-language-server/pull/156

But the challenge is that not everyone use shebangs in their bash files... so I guess we shouldn’t make that a filter? 

If we can get the included files out of tree sitter, then we could potentially parse those files. 