### PR TITLE
Skip analyzing files with a non-bash shebang

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Bash Language Server
 
+## 1.9.0
+
+* Skip analyzing files with a non-bash shebang
+
 ## 1.8.0
 
 * Extend file glob used for pre-analyzing files from `**/*.sh` to `**/*@(.sh|.inc|.bash|.command)`

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
   "description": "A language server for Bash",
   "author": "Mads Hartmann",
   "license": "MIT",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "publisher": "mads-hartmann",
   "main": "./out/server.js",
   "typings": "./out/server.d.ts",

--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -119,7 +119,9 @@ describe('fromRoot', () => {
     expect(newAnalyzer).toBeDefined()
 
     const FIXTURE_FILES_MATCHING_GLOB = 8
-    const LOG_LINES = FIXTURE_FILES_MATCHING_GLOB + 3
+
+    // Intro, stats on glob, one file skipped due to shebang, and outro
+    const LOG_LINES = FIXTURE_FILES_MATCHING_GLOB + 4
 
     expect(connection.console.log).toHaveBeenCalledTimes(LOG_LINES)
     expect(connection.console.log).toHaveBeenNthCalledWith(

--- a/server/src/analyser.ts
+++ b/server/src/analyser.ts
@@ -54,6 +54,8 @@ export default class Analyzer {
 
       const filePaths = await getFilePaths({ globPattern, rootPath })
 
+      // TODO: we could load all files without extensions: globPattern: '**/[^.]'
+
       connection.console.log(
         `Glob resolved with ${filePaths.length} files after ${getTimePassed()}`,
       )

--- a/server/src/util/__tests__/shebang.test.ts
+++ b/server/src/util/__tests__/shebang.test.ts
@@ -1,0 +1,31 @@
+import { hasBashShebang } from '../shebang'
+
+describe('hasBashShebang', () => {
+  it('returns false for empty file', () => {
+    expect(hasBashShebang('')).toBe(false)
+  })
+
+  it('returns false for python files', () => {
+    expect(hasBashShebang(`#!/usr/bin/env python2.7\n# set -x`)).toBe(false)
+  })
+
+  it('returns true for "#!/bin/sh -"', () => {
+    expect(hasBashShebang('#!/bin/sh -')).toBe(true)
+    expect(hasBashShebang('#!/bin/sh - ')).toBe(true)
+  })
+
+  it('returns true for "#!/usr/bin/env bash"', () => {
+    expect(hasBashShebang('#!/usr/bin/env bash')).toBe(true)
+    expect(hasBashShebang('#!/usr/bin/env bash ')).toBe(true)
+  })
+
+  it('returns true for "#!/bin/sh"', () => {
+    expect(hasBashShebang('#!/bin/sh')).toBe(true)
+    expect(hasBashShebang('#!/bin/sh ')).toBe(true)
+  })
+
+  it('returns true for "#!/bin/bash"', () => {
+    expect(hasBashShebang('#!/bin/bash')).toBe(true)
+    expect(hasBashShebang('#!/bin/bash ')).toBe(true)
+  })
+})

--- a/server/src/util/shebang.ts
+++ b/server/src/util/shebang.ts
@@ -1,0 +1,19 @@
+const SHEBANG_REGEXP = /^#!(.*)/
+
+export function getShebang(fileContent: string): string | null {
+  const match = SHEBANG_REGEXP.exec(fileContent)
+  if (!match || !match[1]) {
+    return null
+  }
+
+  return match[1].replace('-', '').trim()
+}
+
+export function isBashShebang(shebang: string): boolean {
+  return shebang.endsWith('bash') || shebang.endsWith('sh')
+}
+
+export function hasBashShebang(fileContent: string): boolean {
+  const shebang = getShebang(fileContent)
+  return shebang ? isBashShebang(shebang) : false
+}


### PR DESCRIPTION
Issue: #47 

We now skip analyzing files if has a shebang AND that shebang is not `bash` or `sh`. 

I'll wait to merge until CI can deploy this for us.