### PR TITLE
Improve completion handler and wordAtPoint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 **/out
 **/node_modules
 !.eslintrc.js
+coverage

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Bash Language Server
 
+## 1.10.0
+
+* Improved completion handler and support  auto-completion and documentation for [bash reserved words](https://www.gnu.org/software/bash/manual/html_node/Reserved-Word-Index.html) (https://github.com/mads-hartmann/bash-language-server/pull/192)
+
 ## 1.9.0
 
 * Skip analyzing files with a non-bash shebang

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
   "description": "A language server for Bash",
   "author": "Mads Hartmann",
   "license": "MIT",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "publisher": "mads-hartmann",
   "main": "./out/server.js",
   "typings": "./out/server.d.ts",

--- a/server/src/__tests__/__snapshots__/analyzer.test.ts.snap
+++ b/server/src/__tests__/__snapshots__/analyzer.test.ts.snap
@@ -131,7 +131,7 @@ Array [
   Object {
     "data": Object {
       "name": "ret",
-      "type": "function",
+      "type": 3,
     },
     "kind": 6,
     "label": "ret",
@@ -139,7 +139,7 @@ Array [
   Object {
     "data": Object {
       "name": "configures",
-      "type": "function",
+      "type": 3,
     },
     "kind": 6,
     "label": "configures",
@@ -147,7 +147,7 @@ Array [
   Object {
     "data": Object {
       "name": "npm_config_loglevel",
-      "type": "function",
+      "type": 3,
     },
     "kind": 6,
     "label": "npm_config_loglevel",
@@ -155,7 +155,7 @@ Array [
   Object {
     "data": Object {
       "name": "node",
-      "type": "function",
+      "type": 3,
     },
     "kind": 6,
     "label": "node",
@@ -163,7 +163,7 @@ Array [
   Object {
     "data": Object {
       "name": "TMP",
-      "type": "function",
+      "type": 3,
     },
     "kind": 6,
     "label": "TMP",
@@ -171,7 +171,7 @@ Array [
   Object {
     "data": Object {
       "name": "BACK",
-      "type": "function",
+      "type": 3,
     },
     "kind": 6,
     "label": "BACK",
@@ -179,7 +179,7 @@ Array [
   Object {
     "data": Object {
       "name": "tar",
-      "type": "function",
+      "type": 3,
     },
     "kind": 6,
     "label": "tar",
@@ -187,7 +187,7 @@ Array [
   Object {
     "data": Object {
       "name": "MAKE",
-      "type": "function",
+      "type": 3,
     },
     "kind": 6,
     "label": "MAKE",
@@ -195,7 +195,7 @@ Array [
   Object {
     "data": Object {
       "name": "make",
-      "type": "function",
+      "type": 3,
     },
     "kind": 6,
     "label": "make",
@@ -203,7 +203,7 @@ Array [
   Object {
     "data": Object {
       "name": "clean",
-      "type": "function",
+      "type": 3,
     },
     "kind": 6,
     "label": "clean",
@@ -211,7 +211,7 @@ Array [
   Object {
     "data": Object {
       "name": "node_version",
-      "type": "function",
+      "type": 3,
     },
     "kind": 6,
     "label": "node_version",
@@ -219,7 +219,7 @@ Array [
   Object {
     "data": Object {
       "name": "t",
-      "type": "function",
+      "type": 3,
     },
     "kind": 6,
     "label": "t",
@@ -227,7 +227,7 @@ Array [
   Object {
     "data": Object {
       "name": "url",
-      "type": "function",
+      "type": 3,
     },
     "kind": 6,
     "label": "url",
@@ -235,7 +235,7 @@ Array [
   Object {
     "data": Object {
       "name": "ver",
-      "type": "function",
+      "type": 3,
     },
     "kind": 6,
     "label": "ver",
@@ -243,7 +243,7 @@ Array [
   Object {
     "data": Object {
       "name": "isnpm10",
-      "type": "function",
+      "type": 3,
     },
     "kind": 6,
     "label": "isnpm10",
@@ -251,7 +251,7 @@ Array [
   Object {
     "data": Object {
       "name": "NODE",
-      "type": "function",
+      "type": 3,
     },
     "kind": 6,
     "label": "NODE",

--- a/server/src/__tests__/analyzer.test.ts
+++ b/server/src/__tests__/analyzer.test.ts
@@ -86,8 +86,17 @@ describe('wordAtPoint', () => {
   it('returns current word at a given point', () => {
     analyzer.analyze(CURRENT_URI, FIXTURES.INSTALL)
     expect(analyzer.wordAtPoint(CURRENT_URI, 25, 5)).toEqual('rm')
-    // FIXME: seems like there is an issue here:
-    // expect(analyzer.wordAtPoint(CURRENT_URI, 24, 4)).toEqual('else')
+
+    // FIXME: grammar issue: else is not found
+    // expect(analyzer.wordAtPoint(CURRENT_URI, 24, 5)).toEqual('else')
+
+    expect(analyzer.wordAtPoint(CURRENT_URI, 30, 1)).toEqual(null)
+
+    expect(analyzer.wordAtPoint(CURRENT_URI, 30, 3)).toEqual('ret')
+    expect(analyzer.wordAtPoint(CURRENT_URI, 30, 4)).toEqual('ret')
+    expect(analyzer.wordAtPoint(CURRENT_URI, 30, 5)).toEqual('ret')
+
+    expect(analyzer.wordAtPoint(CURRENT_URI, 38, 5)).toEqual('configures')
   })
 })
 

--- a/server/src/__tests__/server.test.ts
+++ b/server/src/__tests__/server.test.ts
@@ -150,26 +150,20 @@ describe('server', () => {
       {} as any,
     )
 
-    expect(result).toMatchInlineSnapshot(`
-          Array [
-            Object {
-              "data": Object {
-                "name": "rm",
-                "type": "executable",
-              },
-              "kind": 12,
-              "label": "rm",
-            },
-            Object {
-              "data": Object {
-                "name": "rmdir",
-                "type": "executable",
-              },
-              "kind": 12,
-              "label": "rmdir",
-            },
-          ]
-      `)
+    // Limited set
+    expect('length' in result && result.length < 5).toBe(true)
+    expect(result).toEqual(
+      expect.arrayContaining([
+        {
+          data: {
+            name: 'rm',
+            type: 'executable',
+          },
+          kind: expect.any(Number),
+          label: 'rm',
+        },
+      ]),
+    )
   })
 
   it('responds to onCompletion with entire list when no word is found', async () => {

--- a/server/src/__tests__/server.test.ts
+++ b/server/src/__tests__/server.test.ts
@@ -130,7 +130,7 @@ describe('server', () => {
     })
   })
 
-  it('responds to onCompletion when word is found', async () => {
+  it('responds to onCompletion with filtered list when word is found', async () => {
     const { connection, server } = await initializeServer()
     server.register(connection)
 
@@ -142,6 +142,7 @@ describe('server', () => {
           uri: FIXTURE_URI.INSTALL,
         },
         position: {
+          // rm
           line: 25,
           character: 5,
         },
@@ -149,11 +150,29 @@ describe('server', () => {
       {} as any,
     )
 
-    // Entire list
-    expect('length' in result && result.length > 50)
+    expect(result).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "data": Object {
+                "name": "rm",
+                "type": "executable",
+              },
+              "kind": 12,
+              "label": "rm",
+            },
+            Object {
+              "data": Object {
+                "name": "rmdir",
+                "type": "executable",
+              },
+              "kind": 12,
+              "label": "rmdir",
+            },
+          ]
+      `)
   })
 
-  it('responds to onCompletion when no word is found', async () => {
+  it('responds to onCompletion with entire list when no word is found', async () => {
     const { connection, server } = await initializeServer()
     server.register(connection)
 
@@ -165,6 +184,31 @@ describe('server', () => {
           uri: FIXTURE_URI.INSTALL,
         },
         position: {
+          // else
+          line: 24,
+          character: 5,
+        },
+      },
+      {} as any,
+    )
+
+    // Entire list
+    expect('length' in result && result.length > 50).toBe(true)
+  })
+
+  it('responds to onCompletion with empty list when word is a comment', async () => {
+    const { connection, server } = await initializeServer()
+    server.register(connection)
+
+    const onCompletion = connection.onCompletion.mock.calls[0][0]
+
+    const result = await onCompletion(
+      {
+        textDocument: {
+          uri: FIXTURE_URI.INSTALL,
+        },
+        position: {
+          // inside comment
           line: 2,
           character: 1,
         },
@@ -172,7 +216,6 @@ describe('server', () => {
       {} as any,
     )
 
-    // Entire list
-    expect('length' in result && result.length > 50)
+    expect(result).toEqual([])
   })
 })

--- a/server/src/__tests__/server.test.ts
+++ b/server/src/__tests__/server.test.ts
@@ -2,6 +2,7 @@ import * as lsp from 'vscode-languageserver'
 
 import { FIXTURE_FOLDER, FIXTURE_URI } from '../../../testing/fixtures'
 import LspServer from '../server'
+import { CompletionItemDataType } from '../types'
 
 async function initializeServer() {
   const diagnostics: Array<lsp.PublishDiagnosticsParams | undefined> = undefined
@@ -157,7 +158,7 @@ describe('server', () => {
         {
           data: {
             name: 'rm',
-            type: 'executable',
+            type: CompletionItemDataType.Executable,
           },
           kind: expect.any(Number),
           label: 'rm',

--- a/server/src/analyser.ts
+++ b/server/src/analyser.ts
@@ -5,6 +5,7 @@ import * as LSP from 'vscode-languageserver'
 import * as Parser from 'web-tree-sitter'
 
 import { getGlobPattern } from './config'
+import { BashCompletionItem, CompletionItemDataType } from './types'
 import { uniqueBasedOnHash } from './util/array'
 import { flattenArray, flattenObjectValues } from './util/flatten'
 import { getFilePaths } from './util/fs'
@@ -232,7 +233,7 @@ export default class Analyzer {
   /**
    * Find unique symbol completions for the given file.
    */
-  public findSymbolCompletions(uri: string): LSP.CompletionItem[] {
+  public findSymbolCompletions(uri: string): BashCompletionItem[] {
     const hashFunction = ({ name, kind }: LSP.SymbolInformation) => `${name}${kind}`
 
     return uniqueBasedOnHash(this.findSymbols(uri), hashFunction).map(
@@ -241,7 +242,7 @@ export default class Analyzer {
         kind: this.symbolKindToCompletionKind(symbol.kind),
         data: {
           name: symbol.name,
-          type: 'function',
+          type: CompletionItemDataType.Symbol,
         },
       }),
     )

--- a/server/src/analyser.ts
+++ b/server/src/analyser.ts
@@ -328,13 +328,25 @@ export default class Analyzer {
     const document = this.uriToTreeSitterTrees[uri]
     const contents = this.uriToFileContent[uri]
 
-    const node = document.rootNode.namedDescendantForPosition({ row: line, column })
+    if (!document.rootNode) {
+      // Check for lacking rootNode (due to failed parse?)
+      return null
+    }
+
+    const point = { row: line, column }
+
+    const node = TreeSitterUtil.namedLeafDescendantForPosition(point, document.rootNode)
+
+    if (!node) {
+      return null
+    }
 
     const start = node.startIndex
     const end = node.endIndex
     const name = contents.slice(start, end)
 
     // Hack. Might be a problem with the grammar.
+    // TODO: Document this with a test case
     if (name.endsWith('=')) {
       return name.slice(0, name.length - 1)
     }

--- a/server/src/analyser.ts
+++ b/server/src/analyser.ts
@@ -118,17 +118,17 @@ export default class Analyzer {
   }
 
   public async getExplainshellDocumentation({
-    pos,
+    params,
     endpoint,
   }: {
-    pos: LSP.TextDocumentPositionParams
+    params: LSP.TextDocumentPositionParams
     endpoint: string
   }): Promise<any> {
     const leafNode = this.uriToTreeSitterTrees[
-      pos.textDocument.uri
+      params.textDocument.uri
     ].rootNode.descendantForPosition({
-      row: pos.position.line,
-      column: pos.position.character,
+      row: params.position.line,
+      column: params.position.character,
     })
 
     // explainshell needs the whole command, not just the "word" (tree-sitter
@@ -138,7 +138,7 @@ export default class Analyzer {
     // encounters newlines.
     const interestingNode = leafNode.type === 'word' ? leafNode.parent : leafNode
 
-    const cmd = this.uriToFileContent[pos.textDocument.uri].slice(
+    const cmd = this.uriToFileContent[params.textDocument.uri].slice(
       interestingNode.startIndex,
       interestingNode.endIndex,
     )
@@ -162,7 +162,7 @@ export default class Analyzer {
       return { ...response, status: 'error' }
     } else {
       const offsetOfMousePointerInCommand =
-        this.uriToTextDocument[pos.textDocument.uri].offsetAt(pos.position) -
+        this.uriToTextDocument[params.textDocument.uri].offsetAt(params.position) -
         interestingNode.startIndex
 
       const match = explainshellResponse.matches.find(

--- a/server/src/builtins.ts
+++ b/server/src/builtins.ts
@@ -63,8 +63,10 @@ export const LIST = [
   'wait',
 ]
 
+const SET = new Set(LIST)
+
 export function isBuiltin(word: string): boolean {
-  return LIST.find(builtin => builtin === word) !== undefined
+  return SET.has(word)
 }
 
 export async function documentation(builtin: string): Promise<string> {

--- a/server/src/reservedWords.ts
+++ b/server/src/reservedWords.ts
@@ -1,0 +1,42 @@
+import * as ShUtil from './util/sh'
+
+// https://www.gnu.org/software/bash/manual/html_node/Reserved-Word-Index.html
+
+export const LIST = [
+  '!',
+  '[[',
+  ']]',
+  '{',
+  '}',
+  'case',
+  'do',
+  'done',
+  'elif',
+  'else',
+  'esac',
+  'fi',
+  'for',
+  'function',
+  'if',
+  'in',
+  'select',
+  'then',
+  'time',
+  'until',
+  'while',
+]
+
+const SET = new Set(LIST)
+
+export function isReservedWord(word: string): boolean {
+  return SET.has(word)
+}
+
+export async function documentation(reservedWord: string): Promise<string> {
+  try {
+    const doc = await ShUtil.execShellScript(`help ${reservedWord}`)
+    return doc || ''
+  } catch (error) {
+    return ''
+  }
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -216,6 +216,11 @@ export default class BashServer {
 
     const currentWord = this.getWordAtPoint(pos)
     if (currentWord) {
+      if (currentWord.startsWith('#')) {
+        // Inside a comment block
+        return []
+      }
+
       // Filter to only return suffixes of the current word
       return allCompletions.filter(item => item.label.startsWith(currentWord))
     }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -214,11 +214,13 @@ export default class BashServer {
       ...builtinsCompletions,
     ]
 
-    // Filter to only return suffixes of the current word
     const currentWord = this.getWordAtPoint(pos)
-    return allCompletions.filter(
-      (x: LSP.CompletionItem) => x.label && x.label.startsWith(currentWord),
-    )
+    if (currentWord) {
+      // Filter to only return suffixes of the current word
+      return allCompletions.filter(item => item.label.startsWith(currentWord))
+    }
+
+    return allCompletions
   }
 
   private async onCompletionResolve(

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -208,7 +208,17 @@ export default class BashServer {
       },
     }))
 
-    return [...symbolCompletions, ...programCompletions, ...builtinsCompletions]
+    const allCompletions = [
+      ...symbolCompletions,
+      ...programCompletions,
+      ...builtinsCompletions,
+    ]
+
+    // Filter to only return suffixes of the current word
+    const currentWord = this.getWordAtPoint(pos)
+    return allCompletions.filter(
+      (x: LSP.CompletionItem) => x.label && x.label.startsWith(currentWord),
+    )
   }
 
   private async onCompletionResolve(

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -223,6 +223,7 @@ export default class BashServer {
       },
     }))
 
+    // TODO: we have duplicates here (e.g. echo is both a builtin AND have a man page)
     const allCompletions = [
       ...symbolCompletions,
       ...programCompletions,

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -1,0 +1,15 @@
+import * as LSP from 'vscode-languageserver'
+
+export enum CompletionItemDataType {
+  Builtin,
+  Executable,
+  ReservedWord,
+  Symbol,
+}
+
+export interface BashCompletionItem extends LSP.CompletionItem {
+  data: {
+    type: CompletionItemDataType
+    name: string
+  }
+}

--- a/server/src/util/tree-sitter.ts
+++ b/server/src/util/tree-sitter.ts
@@ -1,5 +1,5 @@
 import { Range } from 'vscode-languageserver/lib/main'
-import { SyntaxNode } from 'web-tree-sitter'
+import { Point, SyntaxNode } from 'web-tree-sitter'
 
 export function forEach(node: SyntaxNode, cb: (n: SyntaxNode) => void) {
   cb(node)
@@ -51,4 +51,57 @@ export function findParent(
     node = node.parent
   }
   return null
+}
+
+/**
+ * Given a tree and a point, try to find the named leaf node that the point corresponds to.
+ * This is a helper for wordAtPoint, useful in cases where the point occurs at the boundary of
+ * a word so the normal behavior of "namedDescendantForPosition" does not find the desired leaf.
+ * For example, if you do
+ * > (new Parser()).setLanguage(bash).parse("echo 42").rootNode.descendantForIndex(4).text
+ * then you get 'echo 42', not the leaf node for 'echo'.
+ *
+ * TODO: the need for this function might reveal a flaw in tree-sitter-bash.
+ */
+export function namedLeafDescendantForPosition(
+  point: Point,
+  rootNode: SyntaxNode,
+): SyntaxNode | null {
+  const node = rootNode.namedDescendantForPosition(point)
+
+  if (node.childCount === 0) {
+    return node
+  } else {
+    // The node wasn't a leaf. Try to figure out what word we should use.
+    const nodeToUse = searchForLeafNode(point, node)
+    if (nodeToUse) {
+      return nodeToUse
+    } else {
+      return null
+    }
+  }
+}
+
+function searchForLeafNode(point: Point, parent: SyntaxNode): SyntaxNode | null {
+  let child: SyntaxNode = parent.firstNamedChild
+  while (child) {
+    if (
+      pointsEqual(child.startPosition, point) ||
+      pointsEqual(child.endPosition, point)
+    ) {
+      if (child.childCount === 0) {
+        return child
+      } else {
+        return searchForLeafNode(point, child)
+      }
+    }
+
+    child = child.nextNamedSibling
+  }
+
+  return null
+}
+
+function pointsEqual(point1: Point, point2: Point) {
+  return point1.row === point2.row && point1.column === point2.column
 }


### PR DESCRIPTION
Solves https://github.com/mads-hartmann/bash-language-server/issues/83

This is an iteration on the great work by @thomasjm (see context in https://github.com/mads-hartmann/bash-language-server/pull/119). It improves several aspects of the server:
- detection of a word at a given point is now a lot more accurate (this is used for completion, hovering, etc) and fixes some issues with the tree sitter grammar
- we now support auto-completion and documentation for [bash reserved words](https://www.gnu.org/software/bash/manual/html_node/Reserved-Word-Index.html) (e.g. `case`, `do`, `if`, `while`)
- the completion feedback should be improved a lot by doing suffix filtering (i.e. not suggesting completions that doesn't begin with the current word)
- improved log statements that hopefully makes debugging easier

## Before (left) and after (right)

I've done a bunch of manual testing, and tried to document the results here:

#### Removed weird autocomplete on `set -x` (due to improved word handling):

<img width="48%" alt="Screenshot 2020-03-03 21 43 08" src="https://user-images.githubusercontent.com/1260305/75818201-bf0e0280-5d98-11ea-98ea-be540ea09e78.png"><img width="48%" alt="Screenshot 2020-03-03 21 52 32" src="https://user-images.githubusercontent.com/1260305/75818520-4e1b1a80-5d99-11ea-9fd9-b1798cb0368f.png">

#### Autocompletion when a word is already written (note that we have duplications here with builtins and man pages):

<img width="48%" alt="Screenshot 2020-03-03 22 00 53" src="https://user-images.githubusercontent.com/1260305/75819209-7fe0b100-5d9a-11ea-8ccd-2a91b0a9bc00.png"><img width="48%" alt="Screenshot 2020-03-03 22 00 38" src="https://user-images.githubusercontent.com/1260305/75819215-82dba180-5d9a-11ea-9b27-2fa99de6c48a.png">

#### Bash reserved words are now supported (e.g. if, else)

<img width="48%" alt="Screenshot 2020-03-03 23 15 48" src="https://user-images.githubusercontent.com/1260305/75825104-0601f500-5da5-11ea-90df-85856ff07d23.png"><img width="48%" alt="Screenshot 2020-03-03 23 15 35" src="https://user-images.githubusercontent.com/1260305/75825096-039f9b00-5da5-11ea-9d12-c02b586071f0.png">

This also solved the `case` / `esac` issue reported in https://github.com/mads-hartmann/bash-language-server/issues/83